### PR TITLE
[INVESTIGATION] Undefined propTypes in original component

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -31,4 +31,7 @@ Button.propTypes = {
   block: PropTypes.bool,
 };
 
+console.log("Button.propTypes:", Button.propTypes)
+
+
 export { Button as default };

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -4,7 +4,8 @@ import ButtonB from 'react-bootstrap/Button';
 
 
 function Button(props) {
-  console.log("button!")
+  console.log("ButtonB.defaultProps:", ButtonB.defaultProps)
+  console.log("ButtonB.propTypes:", ButtonB.propTypes)
   return (
     <ButtonB {...props} onClick={props.onClick}>
       {props.children}

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -4,6 +4,7 @@ import ButtonB from 'react-bootstrap/Button';
 
 
 function Button(props) {
+  console.log("button!")
   return (
     <ButtonB {...props} onClick={props.onClick}>
       {props.children}

--- a/src/Button/presets/0-default.jsx
+++ b/src/Button/presets/0-default.jsx
@@ -4,6 +4,6 @@ import Button from "../Button";
 export default (
   <Button
     uxpId="action1">
-    NEW - Sign Up
+    NEW2 - Sign Up
   </Button>
 );

--- a/src/Button/presets/0-default.jsx
+++ b/src/Button/presets/0-default.jsx
@@ -4,6 +4,6 @@ import Button from "../Button";
 export default (
   <Button
     uxpId="action1">
-    NEW4 - Sign Up
+    NEW5 - Sign Up
   </Button>
 );

--- a/src/Button/presets/0-default.jsx
+++ b/src/Button/presets/0-default.jsx
@@ -4,6 +4,6 @@ import Button from "../Button";
 export default (
   <Button
     uxpId="action1">
-    NEW6 - Sign Up
+    NEW9 - Sign Up
   </Button>
 );

--- a/src/Button/presets/0-default.jsx
+++ b/src/Button/presets/0-default.jsx
@@ -4,6 +4,6 @@ import Button from "../Button";
 export default (
   <Button
     uxpId="action1">
-    NEW5 - Sign Up
+    NEW6 - Sign Up
   </Button>
 );

--- a/src/Button/presets/0-default.jsx
+++ b/src/Button/presets/0-default.jsx
@@ -4,6 +4,6 @@ import Button from "../Button";
 export default (
   <Button
     uxpId="action1">
-    Sign Up
+    NEW - Sign Up
   </Button>
 );

--- a/src/Button/presets/0-default.jsx
+++ b/src/Button/presets/0-default.jsx
@@ -4,6 +4,6 @@ import Button from "../Button";
 export default (
   <Button
     uxpId="action1">
-    NEW2 - Sign Up
+    NEW3 - Sign Up
   </Button>
 );

--- a/src/Button/presets/0-default.jsx
+++ b/src/Button/presets/0-default.jsx
@@ -4,6 +4,6 @@ import Button from "../Button";
 export default (
   <Button
     uxpId="action1">
-    NEW3 - Sign Up
+    NEW4 - Sign Up
   </Button>
 );


### PR DESCRIPTION
If you want to integrate an existing DS w/UXPin Merge (like [react-bootstrap](https://github.com/react-bootstrap/react-bootstrap)), you likely need to use wrapper components. This means that you then need to replicate the properties for every component in the wrapper. That's a lot of work.

For example, [look at this react-bootstrap Button component](https://github.com/react-bootstrap/react-bootstrap/blob/master/src/Button.tsx). It defines 9 properties (variant, size, etc). The traditional wrapper approach would require me to re-define all those properties in a wrapper. [I started this here](https://github.com/uxpin-merge/react-bootstrap-merge/blob/no_props/src/Button/Button.js).

However, lets say there are 50 components w/10 properties each in a DS. That'd be 500 properties to keep in sync!

# Passing through the original component's propTypes?

I was curious if I could be lazy and basically do this in my wrapper function:

Button.propTypes = ButtonB.propTypes

However, ButtonB.propTypes is `undefined`. I'm confused. This is [set here](https://github.com/react-bootstrap/react-bootstrap/blob/master/src/Button.tsx#L141) in the original component. I'm able to access displayName and defaultProps which appear to be set in the same way.

If I try to read the new wrapper component's propTypes, this works fine.

You can see this in the web console output when the Button component is rendered in experiment mode (run `uxpin-merge` in the top-level directory):

![image](https://user-images.githubusercontent.com/7880/97343434-1cd1ec00-184d-11eb-9319-b65b2d93a306.png)

```
Button.propTypes: 
Object { onClick: checkType(), children: checkType(), size: checkType(), block: checkType() }
rollbar.min.js:2:24499
ButtonB.defaultProps: 
Object { variant: "primary", active: false, disabled: false }
rollbar.min.js:2:24499
ButtonB.propTypes: undefined
```

Any ideas why? I'm sure it is something obvious that I'm just clueless on.
